### PR TITLE
Cleanup node stuff in images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 
 env:
   - DOCKER_FILE_PATH=./elasticsearch/6.1.1/ TAG=es6.1.1
-#  - DOCKER_FILE_PATH=./nodejs/6/ TAG=node6
-#  - DOCKER_FILE_PATH=./nodejs/8/ TAG=node8
   - DOCKER_FILE_PATH=./python-gis-node/python3/ TAG=py3.6
   - DOCKER_FILE_PATH=./python-gis-node/python3/circle-ci/ TAG=py3.6-ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: required
 
 env:
   - DOCKER_FILE_PATH=./elasticsearch/6.1.1/ TAG=es6.1.1
-  - DOCKER_FILE_PATH=./nodejs/6/ TAG=node6
-  - DOCKER_FILE_PATH=./nodejs/8/ TAG=node8
+#  - DOCKER_FILE_PATH=./nodejs/6/ TAG=node6
+#  - DOCKER_FILE_PATH=./nodejs/8/ TAG=node8
   - DOCKER_FILE_PATH=./python-gis-node/python3/ TAG=py3.6
   - DOCKER_FILE_PATH=./python-gis-node/python3/circle-ci/ TAG=py3.6-ci
 

--- a/nodejs/6/Dockerfile
+++ b/nodejs/6/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:6
-
-# Install bower and gulp, allow bower to run as root:
-# https://github.com/bower/bower/issues/1752#issuecomment-113455403
-RUN npm install -g bower gulp && \
-    echo '{ "allow_root": true }' > /root/.bowerrc

--- a/nodejs/8/Dockerfile
+++ b/nodejs/8/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:8
-
-# Install bower and gulp, allow bower to run as root:
-# https://github.com/bower/bower/issues/1752#issuecomment-113455403
-RUN npm install -g bower gulp && \
-    echo '{ "allow_root": true }' > /root/.bowerrc

--- a/python-gis-node/python3/Dockerfile
+++ b/python-gis-node/python3/Dockerfile
@@ -2,12 +2,3 @@ FROM python:3.6
 
 # Install GEOS and GDAL
 RUN apt-get update && apt-get install -y libgeos-dev libgdal-dev python3-gdal
-
-# Install Nodejs 6
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280 86E50310 && \
-  echo "deb http://deb.nodesource.com/node_6.x jessie main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  apt-get update -qq ; \
-  apt-get install -y -qq nodejs
-
-# Allow Bower to run as root  : https://github.com/bower/bower/issues/1752#issuecomment-113455403
-RUN echo '{ "allow_root": true }' > /root/.bowerrc

--- a/python-gis-node/python3/circle-ci/Dockerfile
+++ b/python-gis-node/python3/circle-ci/Dockerfile
@@ -1,4 +1,13 @@
-FROM founders4schools/dockerfiles:py3.6
+FROM python:3.6
+
+# Install GEOS and GDAL
+RUN apt-get update && apt-get install -y libgeos-dev libgdal-dev python3-gdal
+
+# Install Nodejs 6
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280 86E50310 && \
+  echo "deb http://deb.nodesource.com/node_6.x jessie main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update -qq ; \
+  apt-get install -y -qq nodejs
 
 # Command lines utils that needs to be in the PATH
 RUN pip3 install coverage codecov fabric3 flake8


### PR DESCRIPTION
- Remove node images, use the official ones
- Remove node installation from the Python base image
- Build CI image from the official Python image, to avoid basing it on the previous version of our Python one